### PR TITLE
Plugin crushes with 4.25.1

### DIFF
--- a/Source/KantanDocGen/Private/NodeDocsGenerator.cpp
+++ b/Source/KantanDocGen/Private/NodeDocsGenerator.cpp
@@ -177,6 +177,7 @@ bool FNodeDocsGenerator::GenerateNodeImage(UEdGraphNode* Node, FNodeProcessingSt
 		ReadPixelFlags.SetLinearToGamma(true); // @TODO: is this gamma correction, or something else?
 
 		PixelData = MakeUnique<TImagePixelData<FColor>>(FIntPoint((int32)Desired.X, (int32)Desired.Y));
+		PixelData->Pixels.SetNumUninitialized(Desired.X * Desired.Y);
 
 		if(RTResource->ReadPixelsPtr(PixelData->Pixels.GetData(), ReadPixelFlags, Rect) == false)
 		{

--- a/Source/KantanDocGen/Private/NodeDocsGenerator.cpp
+++ b/Source/KantanDocGen/Private/NodeDocsGenerator.cpp
@@ -177,7 +177,6 @@ bool FNodeDocsGenerator::GenerateNodeImage(UEdGraphNode* Node, FNodeProcessingSt
 		ReadPixelFlags.SetLinearToGamma(true); // @TODO: is this gamma correction, or something else?
 
 		PixelData = MakeUnique<TImagePixelData<FColor>>(FIntPoint((int32)Desired.X, (int32)Desired.Y));
-		PixelData->Pixels.SetNumUninitialized(Desired.X * Desired.Y);
 
 		if(RTResource->ReadPixelsPtr(PixelData->Pixels.GetData(), ReadPixelFlags, Rect) == false)
 		{


### PR DESCRIPTION
FNodeDocsGenerator::GenerateNodeImage() fails with exeption "Access violation writing location 0x0000000000000000" inside
RTResource->ReadPixelsPtr(PixelData->Pixels.GetData(), ReadPixelFlags, Rect)
call. PixelData->Pixels.GetData() is NULL in 4.25, so in FRenderTarget::ReadPixelsPtr OutImageBytes is NULL with kind of predictable outeome.

I'm not sure if this fix is good enough, but at least it works now.